### PR TITLE
[INT-515] PHP wrapper: change request method to POST for the create worker call

### DIFF
--- a/src/resources/Workers.php
+++ b/src/resources/Workers.php
@@ -11,7 +11,7 @@ class Workers extends Resources
 		parent::__construct($api);
 		$this->defineTimeout();
 		$this->endpoints([
-			'create' =>  ['method' => 'GET', 'path' => '/workers'],
+			'create' =>  ['method' => 'POST', 'path' => '/workers'],
 			'get' => [
 				'method' => 'GET', 'path' => '/workers/:workerId',
 				'altPath' => '/workers', 'queryParams' => true


### PR DESCRIPTION
## Problem

PHP wrapper is using GET for create worker endpoint but it must be a POST endpoint according to our API 


## Solution

Fixed request method since create worker endpoint is a POST method