### PR TITLE
INT-398: Announce OSS releases on Slack automatically

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -5,6 +5,7 @@ on:
     types: [published]
 
 jobs:
+
   notify:
     needs: test
     runs-on: ubuntu-latest
@@ -18,7 +19,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":php: A new version of `php-onfleet` has been released: `${{ github.event.release.tag_name }}`"
+                    "text": ":php: A new version of `php-onfleet` has been released: `${{ github.event.release.tag_name }}` :tada:"
                   },
                   "accessory": {
                     "type": "button",

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,36 @@
+name: PHP Composer
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: slackapi/slack-github-action@v1.18.0
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":php: A new version of `php-onfleet` has been released: `${{ github.event.release.tag_name }}`"
+                  },
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "See details"
+                    },
+                    "url": "${{ github.event.release.html_url }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
**Describe the solution**
When creating an open-source release we want to announce it on the #internal-tools channel, automating what we currently do manually after each release.

---

**Added**

- Announce automatically a new open-source release on Slack channels