### PR TITLE
[INT-1313][php-onfleet] Delivery Manifest endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.5] - 2024-05-17
+### Added
+- Added support for Worker's Route Delivery Manifest
+
 ## [1.0.4] - 2023-10-05
 ### Fixed
 - Removed library that causes conflicts with Laravel framework

--- a/README.es.md
+++ b/README.es.md
@@ -90,7 +90,7 @@ Estas son las operaciones disponibles para cada endpoint:
 | [Tasks](https://docs.onfleet.com/reference#tasks) | get(query), get(id), get(shortId, 'shortId') | create(obj), clone(id), forceComplete(id), batch(obj), autoAssign(obj), matchMetadata(obj) | update(id, obj) | deleteOne(id) |
 | [Teams](https://docs.onfleet.com/reference#teams) | get(), get(id), getWorkerEta(id, obj) | create(obj), autoDispatch(id, obj) | update(id, obj), insertTask(id, obj) | deleteOne(id) |
 | [Webhooks](https://docs.onfleet.com/reference#webhooks) | get() | create(obj) | x | deleteOne(id) |
-| [Workers](https://docs.onfleet.com/reference#workers) | get(), get(query), get(id), getByLocation(obj), getSchedule(id) | create(obj), setSchedule(id, obj), matchMetadata(obj) | update(id, obj), insertTask(id, obj) | deleteOne(id) |
+| [Workers](https://docs.onfleet.com/reference#workers) | get(), get(query), get(id), getByLocation(obj), getSchedule(id) | create(obj), setSchedule(id, obj), matchMetadata(obj), getDeliveryManifest(obj) | update(id, obj), insertTask(id, obj) | deleteOne(id) |
 
 #### Peticiones GET
 Para obtener todos los elementos disponibles en un recurso, éstas llamadas retornan un `Promise` con el arreglo de los resultados:
@@ -179,6 +179,20 @@ $datos = [
 $onfleet->workers->create($datos);
 ```
 
+##### Ejemplos de `getDeliveryManifest()`
+
+```php
+$data = [
+  "hubId" => "<hubId>", // Required
+  "workerId" => "<workerId>", // Required
+  "googleApiKey" => "<googleApiKey>", // Optional
+  "startDate" => "<startDate>", // Optional
+  "endDate" => "<endDate>" // Optional
+];
+
+$onfleet->workers->getDeliveryManifest($data);
+```
+
 Otras peticiones POST incluyen `clone`, `forceComplete`, `batchCreate`, `autoAssign` en el recurso *Tasks*; `setSchedule` en el recurso *Workers*; `autoDispatch` en el recurso *Teams*; y `matchMetadata` en todos los recursos que lo soportan. Por ejemplo:
 
 ```php
@@ -188,13 +202,14 @@ $onfleet->tasks->batchCreate($datos);
 $onfleet->tasks->autoAssign($datos);
 
 $onfleet->workers->setSchedule('<24_digit_ID>', $datos);
+$onfleet->workers->getDeliveryManifest($data);
 
 $onfleet->teams->autoDispatch('<24_digit_ID>', $datos);
 
 $onfleet-><entity_name_pluralized>->matchMetadata($datos);
 ```
 
-Para más información, podemos consultar la documentación sobre [`clone`](https://docs.onfleet.com/reference#clone-task), [`forceComplete`](https://docs.onfleet.com/reference#complete-task), [`batchCreate`](https://docs.onfleet.com/reference#create-tasks-in-batch), [`autoAssign`](https://docs.onfleet.com/reference#automatically-assign-list-of-tasks), [`setSchedule`](https://docs.onfleet.com/reference#set-workers-schedule). [`matchMetadata`](https://docs.onfleet.com/reference#querying-by-metadata) y [`autoDispatch`](https://docs.onfleet.com/reference#team-auto-dispatch).
+Para más información, podemos consultar la documentación sobre [`clone`](https://docs.onfleet.com/reference#clone-task), [`forceComplete`](https://docs.onfleet.com/reference#complete-task), [`batchCreate`](https://docs.onfleet.com/reference#create-tasks-in-batch), [`autoAssign`](https://docs.onfleet.com/reference#automatically-assign-list-of-tasks), [`setSchedule`](https://docs.onfleet.com/reference#set-workers-schedule). [`matchMetadata`](https://docs.onfleet.com/reference#querying-by-metadata), [`getDeliveryManifest`](https://docs.onfleet.com/reference/delivery-manifest) y [`autoDispatch`](https://docs.onfleet.com/reference#team-auto-dispatch).
 
 #### Peticiones PUT
 Para modificar un elemento de un recurso:

--- a/README.es.md
+++ b/README.es.md
@@ -186,8 +186,8 @@ $data = [
   "hubId" => "<hubId>", // Required
   "workerId" => "<workerId>", // Required
   "googleApiKey" => "<googleApiKey>", // Optional
-  "startDate" => "<startDate>", // Optional
-  "endDate" => "<endDate>" // Optional
+  "startDate" => "<startDate>", // Optional - Timestamp format e.g. 1557936000000
+  "endDate" => "<endDate>" // Optional - Timestamp format e.g. 1557936000000
 ];
 
 $onfleet->workers->getDeliveryManifest($data);

--- a/README.md
+++ b/README.md
@@ -204,8 +204,8 @@ $data = [
   "hubId" => "<hubId>", // Required
   "workerId" => "<workerId>", // Required
   "googleApiKey" => "<googleApiKey>", // Optional
-  "startDate" => "<startDate>", // Optional
-  "endDate" => "<endDate>" // Optional
+  "startDate" => "<startDate>", // Optional - Timestamp format e.g. 1557936000000
+  "endDate" => "<endDate>" // Optional - Timestamp format e.g. 1557936000000
 ];
 
 $onfleet->workers->getDeliveryManifest($data);

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Here are the operations available for each entity:
 |             [Tasks](https://docs.onfleet.com/reference#tasks)              |          get(query), get(id), get(shortId, 'shortId')           | create(obj), clone(id), forceComplete(id), batch(obj), autoAssign(obj), matchMetadata(obj) |           update(id, obj)            | deleteOne(id) |
 |             [Teams](https://docs.onfleet.com/reference#teams)              |              get(), get(id), getWorkerEta(id, obj)              |                             create(obj), autoDispatch(id, obj)                             | update(id, obj), insertTask(id, obj) | deleteOne(id) |
 |          [Webhooks](https://docs.onfleet.com/reference#webhooks)           |                              get()                              |                                        create(obj)                                         |                  x                   | deleteOne(id) |
-|           [Workers](https://docs.onfleet.com/reference#workers)            | get(), get(query), get(id), getByLocation(obj), getSchedule(id) |                   create(obj), setSchedule(id, obj), matchMetadata(obj)                    | update(id, obj), insertTask(id, obj) | deleteOne(id) |
+|           [Workers](https://docs.onfleet.com/reference#workers)            | get(), get(query), get(id), getByLocation(obj), getSchedule(id) |                   create(obj), setSchedule(id, obj), matchMetadata(obj), getDeliveryManifest(obj)                  | update(id, obj), insertTask(id, obj) | deleteOne(id) |
 
 #### GET Requests
 
@@ -197,6 +197,20 @@ $data = [
 $onfleet->workers->create($data);
 ```
 
+##### Examples of `getDeliveryManifest()`
+
+```php
+$data = [
+  "hubId" => "<hubId>", // Required
+  "workerId" => "<workerId>", // Required
+  "googleApiKey" => "<googleApiKey>", // Optional
+  "startDate" => "<startDate>", // Optional
+  "endDate" => "<endDate>" // Optional
+];
+
+$onfleet->workers->getDeliveryManifest($data);
+```
+
 Extended POST requests include `clone`, `forceComplete`, `batchCreate`, `autoAssign` on the _Tasks_ endpoint; `setSchedule` on the _Workers_ endpoint; `autoDispatch` on the _Teams_ endpoint; and `matchMetadata` on all supported entities. For instance:
 
 ```php
@@ -206,13 +220,14 @@ $onfleet->tasks->batchCreate($data);
 $onfleet->tasks->autoAssign($data);
 
 $onfleet->workers->setSchedule('<24_digit_ID>', $data);
+$onfleet->workers->getDeliveryManifest($data);
 
 $onfleet->teams->autoDispatch('<24_digit_ID>', $data);
 
 $onfleet-><entity_name_pluralized>->matchMetadata($data);
 ```
 
-For more details, check our documentation on [`clone`](https://docs.onfleet.com/reference#clone-task), [`forceComplete`](https://docs.onfleet.com/reference#complete-task), [`batchCreate`](https://docs.onfleet.com/reference#create-tasks-in-batch), [`autoAssign`](https://docs.onfleet.com/reference#automatically-assign-list-of-tasks), [`setSchedule`](https://docs.onfleet.com/reference#set-workers-schedule), [`matchMetadata`](https://docs.onfleet.com/reference#querying-by-metadata), and [`autoDispatch`](https://docs.onfleet.com/reference#team-auto-dispatch).
+For more details, check our documentation on [`clone`](https://docs.onfleet.com/reference#clone-task), [`forceComplete`](https://docs.onfleet.com/reference#complete-task), [`batchCreate`](https://docs.onfleet.com/reference#create-tasks-in-batch), [`autoAssign`](https://docs.onfleet.com/reference#automatically-assign-list-of-tasks), [`setSchedule`](https://docs.onfleet.com/reference#set-workers-schedule), [`matchMetadata`](https://docs.onfleet.com/reference#querying-by-metadata), [`getDeliveryManifest`](https://docs.onfleet.com/reference/delivery-manifest), and [`autoDispatch`](https://docs.onfleet.com/reference#team-auto-dispatch).
 
 #### PUT Requests
 

--- a/src/Methods.php
+++ b/src/Methods.php
@@ -134,7 +134,7 @@ class Methods
 					$hasBody = true;
 				}
 				if (isset($item['googleApiKey'])) {
-					$api->api->headers["X-API-Key"] = 'Google ' . $item['googleApiKey'];
+					$api->api->headers[] = 'X-API-Key: Google ' . $item['googleApiKey'];
 				}
 				$queryParams = [];
 				if (isset($item['startDate'])) {

--- a/src/Methods.php
+++ b/src/Methods.php
@@ -63,6 +63,7 @@ class Methods
 		$path = $methodData['path'] ?? '';
 		$altPath = $methodData['altPath'] ?? [];
 		$queryParams = $methodData['queryParams'] ?? [];
+		$deliveryManifestObject = $methodData['deliveryManifestObject'] ?? [];
 		$timeoutInMilliseconds = $methodData['timeoutInMilliseconds'] ?? 0;
 
 		$url = "{$api->api->baseUrl}{$path}";
@@ -121,6 +122,33 @@ class Methods
 			}
 			$url = "{$url}{$httpQueryParams}";
 		}
+
+		// Reference https://docs.onfleet.com/reference/delivery-manifest
+		if ($deliveryManifestObject && isset($args[0]) && count($args) > 0) {
+			foreach ($args as $item) {
+				if (isset($item['hubId']) && isset($item['workerId'])) {
+					$body = array(
+						'path' => 'providers/manifest/generate?hubId=' . $item['hubId'] . '&workerId=' . $item['workerId'],
+						'method' => "GET"
+					);
+					$hasBody = true;
+				}
+				if (isset($item['googleApiKey'])) {
+					$api->api->headers["X-API-Key"] = 'Google ' . $item['googleApiKey'];
+				}
+				$queryParams = [];
+				if (isset($item['startDate'])) {
+					$queryParams['startDate'] = $item['startDate'];
+				}
+				if (isset($item['endDate'])) {
+					$queryParams['endDate'] = $item['endDate'];
+				}
+				if (!empty($queryParams)) {
+					$url .= '?' . http_build_query($queryParams);
+				}
+			}
+		}
+		
 
 		$result = $api->api->client->execute($url, $method, $api->api->headers, ($hasBody ? $body : []), $timeoutInMilliseconds);
 

--- a/src/resources/Workers.php
+++ b/src/resources/Workers.php
@@ -25,7 +25,11 @@ class Workers extends Resources
 			'insertTask' =>  ['method' => 'PUT', 'path' => '/containers/workers/:workerId'],
 			'getSchedule' =>  ['method' => 'GET', 'path' => '/workers/:workerId/schedule'],
 			'setSchedule' => ['method' => 'POST', 'path' => '/workers/:workerId/schedule'],
-			'matchMetadata' => ['method' => 'POST', 'path' => '/workers/metadata']
+			'matchMetadata' => ['method' => 'POST', 'path' => '/workers/metadata'],
+			'getDeliveryManifest' => [
+				'method' => 'POST', 'path' => '/integrations/marketplace',
+				'deliveryManifestObject' => true
+			],
 		]);
 	}
 }

--- a/tests/OnfleetTest.php
+++ b/tests/OnfleetTest.php
@@ -453,4 +453,25 @@ class OnfleetTest extends TestCase
 	{
 		return include("Response.php");
 	}
+
+	/**
+	 * @dataProvider data
+	 */
+	public function testGetDeliveryManifest($data)
+	{
+		$curlClient = $this->createMock(CurlClient::class);
+		$curlClient->method('execute')->willReturn(["code" => 200, "success" => true, "data" => $data["getManifestProvider"]]);
+		$onfleet = new Onfleet($data["apiKey"]);
+		$onfleet->api->client = $curlClient;
+		$response = $onfleet->workers->getDeliveryManifest([
+			"hubId" => "kyfYe*wyVbqfomP2HTn5dAe1~*O",
+			"workerId" => "kBUZAb7pREtRn*8wIUCpjnPu",
+			"googleApiKey" => "<google_direction_api_key>",
+			"startDate" => "1455072025000",
+			"endDate" => "1455072025000'",
+		]);
+		self::assertIsArray($response);
+		self::assertSame($response["manifestDate"], 1694199600000);
+		self::assertSame(count($response["turnByTurn"]), 1);
+	}
 }

--- a/tests/Response.php
+++ b/tests/Response.php
@@ -518,7 +518,44 @@ return [
 				"notes" => "Always orders our GSC special",
 				"skipSMSNotifications" => false,
 				"metadata" => []
-			]
+			],
+			"getManifestProvider" => [
+				"manifestDate" => 1694199600000,
+				"departureTime" => 1694199600000,
+				"driver" => [
+				  "name" => "Test One",
+				  "phone" => "+16265555768",
+				],
+				"vehicle" => [
+				  "type" => "CAR",
+				  "description" => "Honda",
+				  "licensePlate" => "12345687",
+				  "color" => "Purple",
+				  "timeLastModified" => 1692746334342,
+				],
+				"hubAddress" => "1111 South Figueroa Street, Los Angeles, California 90015",
+				"turnByTurn" => [
+					[
+					"start_address" => "1403 W Pico Blvd, Los Angeles, CA 90015, USA",
+					"end_address" => "2695 E Katella Ave, Anaheim, CA 92806, USA",
+					"eta" => 1692992466000,
+					"driving_distance" => "30.6 mi",
+					  "steps" => [
+						  "Head southeast on 12th St E toward S Figueroa StPartial restricted usage road",
+						  "Turn right onto Flower St",
+						  "Turn left onto the Interstate 10 E ramp to 18th St",
+						  "Merge onto I-10 E",
+						  "Take the exit onto I-5 S toward Santa Ana",
+						  "Take exit 109A for Katella Ave",
+						  "Turn right onto E Katella AvePass by Comerica Bank (on the right in 1.3 mi)",
+						  "Turn left onto S Douglass Rd",
+						  "Turn right onto Stanley Cup Wy",
+						  "Turn right"
+					  ]
+					]
+				],
+				"totalDistance" => null
+			],
 		]
 	]
 ];


### PR DESCRIPTION
<!---
Loosely inspired by https://keepachangelog.com/en/1.1.0/.

Please add items to their respective section and delete empty sections.
- Added: for new features
- Changed: for changes in existing functionality
- Deprecated: for soon-to-be removed features
- Removed: for now removed features
- Fixed: for any bug fixes
- Security: in case of vulnerabilities
Ideally, each item here will be added into the upcoming release.

DO NOT post internal Onfleet links (e.g. Jira/Confluence) –this is a public space.
-->

**Describe the solution**
New Onfleet Delivery Manifest API endpoint added as `getDeliveryManifest` method. In order to test the mentioned endpoints, the test file was updated using a dummy object.
https://docs.onfleet.com/reference/delivery-manifest

---

**Added**

- Added getDeliveryManifest endpoint
- Support to include Google Maps Directions API key, in this specific format Google <google_direction_api_key> in your HTTP header as X-API-KEY
- Support for optional query parameters `startDate` and `endDate`.
- The test file was updated
- Readme files were updated to support Workers POST method.

**Changed**

**Deprecated**

**Removed**

**Fixed**

**Security**